### PR TITLE
fix: align package identity and remove archived genesis API defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,25 @@
-# Sacred Trinity Quantum Resonance Lattice - Environment Configuration
+# Quantum Pi Forge Fixed — Environment Configuration (frontend)
+# Identity: onenoly1010/quantum-pi-forge-fixed (NOT quantum-pi-forge-ignited)
+# Canon hub: onenoly1010/Quantum-pi-forge
+#
+# DO NOT point API defaults at archived genesis endpoints:
+#   - https://pi-forge-quantum-genesis-1.onrender.com  (ARCHIVED — do not use)
+#   - https://pi-forge-quantum-genesis.railway.app     (legacy — do not use as default)
 
 # =============================================================================
-# API CONFIGURATION
+# API / PUBLIC SURFACE CONFIGURATION
 # =============================================================================
-API_BASE_URL=https://pi-forge-quantum-genesis-1.onrender.com
+# Local backend during development (override in .env when you have a live API)
+API_BASE_URL=http://localhost:8000
 
-# Deployment URLs (for reference)
-RENDER_URL=https://pi-forge-quantum-genesis-1.onrender.com
-VERCEL_RESONANCE_URL=https://quantum-resonance-clean.vercel.app
-GITHUB_PAGES_URL=https://onenoly1010.github.io/quantum-pi-forge-site/
+# Public static / product site (canon deploy from Quantum-pi-forge)
+PUBLIC_SITE_URL=https://quantumpiforge.com
+CANON_REPO_URL=https://github.com/onenoly1010/Quantum-pi-forge
+FRONTEND_REPO_URL=https://github.com/onenoly1010/quantum-pi-forge-fixed
+
+# Optional alternate public surfaces (not API backends)
+GITHUB_PAGES_URL=https://onenoly1010.github.io/quantum-pi-forge-fixed/
+VERCEL_RESONANCE_URL=
 
 # =============================================================================
 # SUPABASE CONFIGURATION (Required)
@@ -90,7 +101,8 @@ PI_NETWORK_WEBHOOK_SECRET=your-webhook-secret-from-pi-developer-portal
 
 # Optional: Server wallet private key for automated payments
 # Only needed if your app sends Pi to users
-PI_NETWORK_WALLET_PRIVATE_KEY=your-wallet-private-key
+# NEVER commit a real private key. Leave unset unless you intentionally operate a hot wallet.
+# PI_NETWORK_WALLET_PRIVATE_KEY=
 
 # =============================================================================
 # 0G ARISTOTLE MAINNET CONFIGURATION

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -61,7 +61,8 @@ jobs:
           # Copy configuration files
           cp railway.toml build/pi-studio/ || true
           cp railway.json build/pi-studio/ || true
-          cp vercel.json build/pi-studio/ || true
+          # vercel.json removed — no Vercel dependency
+          # cp vercel.json build/pi-studio/ || true
           cp Dockerfile build/pi-studio/ || true
           
           # Copy README and config

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -102,7 +102,8 @@ jobs:
           # Copy configuration files
           cp railway.toml build/pi-studio/ || true
           cp railway.json build/pi-studio/ || true
-          cp vercel.json build/pi-studio/ || true
+          # vercel.json removed — no Vercel dependency
+          # cp vercel.json build/pi-studio/ || true
           cp Dockerfile build/pi-studio/ || true
           
           # Copy README and config

--- a/.github/workflows/vercelcheck.yml.disabled
+++ b/.github/workflows/vercelcheck.yml.disabled
@@ -1,0 +1,23 @@
+name: Vercel Deployment Status Check
+
+"on":
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  vercel-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Notify Vercel Status
+        uses: vercel/repository-dispatch/actions/status@v1
+        with:
+          name: Vercel - pi-forge-quantum-genesis deployment status

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 | npm package name | `quantum-pi-forge-ignited` | `quantum-pi-forge-fixed` |
 | Default API base | `https://pi-forge-quantum-genesis-1.onrender.com` (archived) | `http://localhost:8000` (dev) + env override |
 | Vercel static API proxy | Proxied to archived Render genesis | Removed — no silent misrouting |
+| Static build output | `.vercel/output/static` | **`out/`** (no Vercel required) |
+| Vercel CI check | `vercelcheck.yml` | **Disabled** (`vercelcheck.yml.disabled`) |
 | Render service name | `pi-forge-quantum-genesis-open` | `quantum-pi-forge-fixed` |
 
 **Operator action:** copy `.env.example` → `.env`, set `API_BASE_URL` only to a backend you intentionally run. Do not restore archived genesis endpoints unless you are doing historical recovery with explicit approval.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,39 @@
 <!-- REPO_STATUS_BANNER_START -->
-> **Repository Status:** ACTIVE — PRODUCTION FRONTEND CANON  
-> **Public Review Note:** This repository is explicitly classified to prevent ambiguity between production canon, support infrastructure, historical archives, and demos.
+> **Repository Status:** ACTIVE — PRODUCTION FRONTEND (UI)  
+> **Package name:** `quantum-pi-forge-fixed` (not `quantum-pi-forge-ignited`)  
+> **Canon hub (governance, contracts, evidence, primary public site):** [onenoly1010/Quantum-pi-forge](https://github.com/onenoly1010/Quantum-pi-forge)  
+> **Public site:** https://quantumpiforge.com  
+> **Public Review Note:** This repository is the frontend/UI lane. Historical genesis (`pi-forge-quantum-genesis`) is an archive — do not use its Render/Railway URLs as default API targets.
 <!-- REPO_STATUS_BANNER_END -->
 
-# 🌐 Quantum Pi Forge — Coordination Space
+## Migration note (identity + API defaults)
 
-## A Sovereign Hub for the Autonomous Multi‑Agent Constellation
+**What changed**
 
-**🌊 [Constellation Status: LIVE](./CONSTELLATION_ACTIVATION.md)** — The Quantum Pi Forge is activated and operational as of December 22, 2025.
+| Item | Old (incorrect / legacy) | New |
+|------|--------------------------|-----|
+| npm package name | `quantum-pi-forge-ignited` | `quantum-pi-forge-fixed` |
+| Default API base | `https://pi-forge-quantum-genesis-1.onrender.com` (archived) | `http://localhost:8000` (dev) + env override |
+| Vercel static API proxy | Proxied to archived Render genesis | Removed — no silent misrouting |
+| Render service name | `pi-forge-quantum-genesis-open` | `quantum-pi-forge-fixed` |
 
-**📜 [Read the Genesis Declaration](./GENESIS.md)** — The foundational seal of the Quantum Pi Forge ecosystem, minted at Solstice 2025.
+**Operator action:** copy `.env.example` → `.env`, set `API_BASE_URL` only to a backend you intentionally run. Do not restore archived genesis endpoints unless you are doing historical recovery with explicit approval.
+
+See [docs/REPO_IDENTITY_MIGRATION_B_V1.md](docs/REPO_IDENTITY_MIGRATION_B_V1.md).
 
 ---
 
-Welcome to the **Quantum Pi Forge Space** — the central coordination hub for the entire constellation of repositories, services, and agents that make up the Quantum Pi Forge ecosystem.
+# 🌐 Quantum Pi Forge — Frontend / Coordination Space
+
+## Production frontend lane for the Quantum Pi Forge constellation
+
+**📜 Canon governance and contracts:** [Quantum-pi-forge](https://github.com/onenoly1010/Quantum-pi-forge)  
+**📜 Genesis declaration (historical):** [GENESIS.md](./GENESIS.md)
+
+---
+
+Welcome to **quantum-pi-forge-fixed** — the production frontend / coordination UI lane.  
+Governance gates, evidence receipts, Foundry contracts, and the primary public site live in **Quantum-pi-forge**.
 
 This Space exists to:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "4317:4317"   # OTLP gRPC receiver
       - "8889:8889"   # Prometheus metrics exporter
     environment:
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=pi-forge-quantum-genesis
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=quantum-pi-forge-fixed
 
   # Prometheus
   prometheus:

--- a/docs/REPO_IDENTITY_MIGRATION_B_V1.md
+++ b/docs/REPO_IDENTITY_MIGRATION_B_V1.md
@@ -18,6 +18,7 @@ Eliminate active misrouting risk by aligning package identity and default endpoi
 3. **Static build proxy** — `scripts/build.js` no longer rewrites `/api` and `/health` to the archived Render host.
 4. **Deploy labels** — `render.yaml`, `docker-compose.yml` OTEL service name, and `prometheus.yml` labels use `quantum-pi-forge-fixed`.
 5. **README** — status banner + operator migration note.
+6. **Vercel decommission** — static build → `out/`; `vercelcheck.yml` disabled; see `docs/VERCEL_DECOMMISSION_V1.md`.
 
 ## Build scripts consistency
 

--- a/docs/REPO_IDENTITY_MIGRATION_B_V1.md
+++ b/docs/REPO_IDENTITY_MIGRATION_B_V1.md
@@ -1,0 +1,42 @@
+# Repo identity + API defaults migration (B)
+
+Status: APPLIED_ON_BRANCH  
+Scope: `onenoly1010/quantum-pi-forge-fixed` only  
+
+## Purpose
+
+Eliminate active misrouting risk by aligning package identity and default endpoints with the multi-repo architecture:
+
+- **Canon hub:** `onenoly1010/Quantum-pi-forge` (governance, contracts, evidence, quantumpiforge.com)
+- **This repo:** production frontend / UI lane
+- **Archive:** `onenoly1010/pi-forge-quantum-genesis` — historical only
+
+## Changes in this migration
+
+1. **Package identity** — `package.json` / lockfile name set to `quantum-pi-forge-fixed` (was `quantum-pi-forge-ignited`).
+2. **API defaults** — `.env.example` no longer defaults to archived Render genesis (`pi-forge-quantum-genesis-1.onrender.com`).
+3. **Static build proxy** — `scripts/build.js` no longer rewrites `/api` and `/health` to the archived Render host.
+4. **Deploy labels** — `render.yaml`, `docker-compose.yml` OTEL service name, and `prometheus.yml` labels use `quantum-pi-forge-fixed`.
+5. **README** — status banner + operator migration note.
+
+## Build scripts consistency
+
+| Script | Role |
+|--------|------|
+| `npm run dev` | Next.js local UI |
+| `npm run build` | Next.js production build |
+| `npm run build:static` | Legacy static Vercel output (`scripts/build.js`) — no archive proxy |
+| `npm run start` | Next.js start |
+| `npm run lint` | Next lint |
+| `npm run typecheck` | `tsc --noEmit` |
+
+## Safety
+
+- No wallet signing, private key use, mint, liquidity, staking, or bridge activation.
+- Placeholders such as `PI_NETWORK_WALLET_PRIVATE_KEY` in `.env.example` remain empty placeholders only — never commit real keys.
+- Historical docs under `docs/` may still mention genesis URLs for archival narrative; **runtime defaults** must not.
+
+## Follow-on (not this PR)
+
+- **C)** Read-only multi-repo secrets inventory  
+- **A)** `REPO_ROLES.md` on Quantum-pi-forge  

--- a/docs/VERCEL_DECOMMISSION_V1.md
+++ b/docs/VERCEL_DECOMMISSION_V1.md
@@ -1,0 +1,37 @@
+# Vercel decommission v1
+
+Status: APPLIED — this frontend repo no longer requires Vercel  
+Canon production host: **Cloudflare Pages** via `onenoly1010/Quantum-pi-forge` → https://quantumpiforge.com
+
+## Why
+
+- Vercel account is blocked / not used for production
+- Default API and static proxy previously misrouted to archived genesis
+- Constellation canon is Quantum-pi-forge + Cloudflare
+
+## What was removed / disabled
+
+| Item | Action |
+|------|--------|
+| `.vercel/output` build target | Replaced with `out/` in `scripts/build.js` |
+| Vercel Build Output API config | Removed |
+| `.github/workflows/vercelcheck.yml` | Renamed to `.disabled` |
+| `vercel.json` copy in release/test packaging | Commented out (file not present) |
+| Archive Render `/api` proxy | Already removed in identity fix |
+
+## What operators should use
+
+| Goal | Path |
+|------|------|
+| Public production site | https://quantumpiforge.com (Quantum-pi-forge / Cloudflare) |
+| This frontend static build | `npm run build:static` → `out/` |
+| Next.js UI | `npm run build` / `npm run dev` |
+| GH Pages (optional) | Publish `out/` if desired; not required for canon |
+
+## Historical docs
+
+Markdown under `docs/` may still mention `*.vercel.app` for archive narrative. Those are **not** production deploy targets. Do not re-enable Vercel solely to green CI.
+
+## Safety
+
+No wallet signing, mint, liquidity, staking, bridge, or private keys.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "quantum-pi-forge-ignited",
+  "name": "quantum-pi-forge-fixed",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "quantum-pi-forge-ignited",
+      "name": "quantum-pi-forge-fixed",
       "version": "1.0.0",
       "dependencies": {
         "ethers": "^6.17.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
-  "name": "quantum-pi-forge-ignited",
+  "name": "quantum-pi-forge-fixed",
   "version": "1.0.0",
-  "description": "Sovereign AI Governance and DeFi Protocol",
+  "description": "Quantum Pi Forge production frontend (UI). Canon governance/contracts live in onenoly1010/Quantum-pi-forge.",
   "packageManager": "npm@10.9.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/onenoly1010/quantum-pi-forge-fixed.git"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:static": "node scripts/build.js",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "ethers": "^6.17.0",

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
   external_labels:
-    cluster: 'pi-forge-quantum-genesis'
+    cluster: 'quantum-pi-forge-fixed'
     environment: 'development'
 
 scrape_configs:
@@ -18,6 +18,6 @@ scrape_configs:
     static_configs:
       - targets: ['app:8000']
         labels:
-          service: 'pi-forge-quantum-genesis'
+          service: 'quantum-pi-forge-fixed'
     metrics_path: '/api/metrics'
     scrape_interval: 30s

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,7 @@
 services:
   - type: web
-    name: pi-forge-quantum-genesis-open
+    # Service identity matches this repo (not archived genesis)
+    name: quantum-pi-forge-fixed
     runtime: docker
     dockerfilePath: ./Dockerfile
     plan: free
@@ -10,4 +11,6 @@ services:
         value: 8080
       - key: NODE_ENV
         value: production
+      - key: API_BASE_URL
+        value: http://localhost:8000
     healthCheckPath: /health

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -79,12 +79,13 @@ function build() {
 
   // Create Vercel Build Output API config
   const configPath = path.join(vercelOutputDir, 'config.json');
+  // Do not proxy /api to archived genesis Render endpoints.
+  // Configure a supported backend via API_BASE_URL in env when needed.
+  // Canon static site: https://quantumpiforge.com (repo: onenoly1010/Quantum-pi-forge)
   const config = {
     version: 3,
     routes: [
       { handle: "filesystem" },
-      { src: "/api/(.*)", dest: "https://pi-forge-quantum-genesis-1.onrender.com/api/$1" },
-      { src: "/health", dest: "https://pi-forge-quantum-genesis-1.onrender.com/health" },
       { src: "/(.*)", dest: "/index.html" }
     ]
   };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,19 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * Build script for Vercel deployment
- * Uses Vercel Build Output API v3 format (.vercel/output/static)
- * This bypasses .gitignore issues with the public/ directory
+ * Static build for local / GitHub Pages / Cloudflare-style static hosting.
+ * Output: out/ (Vercel Build Output API and .vercel/ paths intentionally removed)
+ * Production canon site: https://quantumpiforge.com (onenoly1010/Quantum-pi-forge)
  */
 
 const fs = require('fs');
 const path = require('path');
 
 const rootDir = path.join(__dirname, '..');
-const vercelOutputDir = path.join(rootDir, '.vercel', 'output');
-const publicDir = path.join(vercelOutputDir, 'static');
+const outputDir = path.join(rootDir, 'out');
 
-// Files to copy from root to public directory
+// Files to copy from root to out/
 const staticFiles = [
   'index.html',
   'ceremonial_interface.html',
@@ -22,14 +21,11 @@ const staticFiles = [
   'pi-forge-integration.js'
 ];
 
-// Directories to copy from root to public directory
+// Directories to copy from root to out/
 const staticDirs = [
   'frontend'
 ];
 
-/**
- * Recursively copy a directory
- */
 function copyDir(src, dest) {
   if (!fs.existsSync(dest)) {
     fs.mkdirSync(dest, { recursive: true });
@@ -49,12 +45,9 @@ function copyDir(src, dest) {
   }
 }
 
-/**
- * Copy a single file
- */
-function copyFile(src, dest) {
+function copyFile(src) {
   const srcPath = path.join(rootDir, src);
-  const destPath = path.join(publicDir, path.basename(src));
+  const destPath = path.join(outputDir, path.basename(src));
 
   if (fs.existsSync(srcPath)) {
     fs.copyFileSync(srcPath, destPath);
@@ -64,47 +57,33 @@ function copyFile(src, dest) {
   }
 }
 
-/**
- * Main build function
- */
 function build() {
-  console.log('Building static assets for Vercel deployment...\n');
+  console.log('Building static assets (no Vercel; output → out/)...\n');
 
-  // Clean and create output directory structure
-  if (fs.existsSync(vercelOutputDir)) {
-    fs.rmSync(vercelOutputDir, { recursive: true });
+  // Remove legacy Vercel output if present
+  const legacyVercel = path.join(rootDir, '.vercel');
+  if (fs.existsSync(legacyVercel)) {
+    fs.rmSync(legacyVercel, { recursive: true, force: true });
+    console.log('✓ Removed legacy .vercel/ directory\n');
   }
-  fs.mkdirSync(publicDir, { recursive: true });
-  console.log('✓ Created .vercel/output/static directory\n');
 
-  // Create Vercel Build Output API config
-  const configPath = path.join(vercelOutputDir, 'config.json');
-  // Do not proxy /api to archived genesis Render endpoints.
-  // Configure a supported backend via API_BASE_URL in env when needed.
-  // Canon static site: https://quantumpiforge.com (repo: onenoly1010/Quantum-pi-forge)
-  const config = {
-    version: 3,
-    routes: [
-      { handle: "filesystem" },
-      { src: "/(.*)", dest: "/index.html" }
-    ]
-  };
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-  console.log('✓ Created config.json\n');
+  if (fs.existsSync(outputDir)) {
+    fs.rmSync(outputDir, { recursive: true });
+  }
+  fs.mkdirSync(outputDir, { recursive: true });
+  console.log('✓ Created out/ directory\n');
 
-  // Copy static files
   console.log('Copying static files:');
   for (const file of staticFiles) {
-    copyFile(file, publicDir);
+    copyFile(file);
   }
   console.log('');
 
-  // Copy static directories
   console.log('Copying static directories:');
   for (const dir of staticDirs) {
     const srcPath = path.join(rootDir, dir);
-    const destPath = path.join(publicDir, dir);
-    
+    const destPath = path.join(outputDir, dir);
+
     if (fs.existsSync(srcPath)) {
       const stats = fs.statSync(srcPath);
       if (stats.isDirectory()) {
@@ -118,11 +97,19 @@ function build() {
     }
   }
 
-  console.log('\n✅ Build completed successfully!');
-  console.log(`📁 Output directory: ${publicDir}\n`);
+  // Simple SPA-friendly _redirects for Cloudflare Pages / static hosts
+  fs.writeFileSync(
+    path.join(outputDir, '_redirects'),
+    '/*    /index.html   200\n'
+  );
+  console.log('✓ Wrote out/_redirects\n');
+
+  console.log('✅ Build completed successfully!');
+  console.log(`📁 Output directory: ${outputDir}\n`);
+  console.log('Note: Production public site is Cloudflare (quantumpiforge.com / Quantum-pi-forge).');
+  console.log('      This repo no longer requires Vercel.\n');
 }
 
-// Run the build
 try {
   build();
   process.exit(0);


### PR DESCRIPTION
## Summary
Fixes active misrouting risk in `quantum-pi-forge-fixed` (priority **B** from multi-repo activation plan).

- Package identity: `quantum-pi-forge-ignited` → **`quantum-pi-forge-fixed`**
- Default API no longer points at archived **`pi-forge-quantum-genesis-1.onrender.com`**
- Removed Vercel static `/api` + `/health` proxy to that archived host
- Aligned Render / OTEL / Prometheus service labels with this repo name
- README + `docs/REPO_IDENTITY_MIGRATION_B_V1.md` document frontend vs canon hub

## Canon split
| Repo | Role |
|------|------|
| [Quantum-pi-forge](https://github.com/onenoly1010/Quantum-pi-forge) | Governance, contracts, evidence, public site |
| **this repo** | Production frontend / UI |
| `pi-forge-quantum-genesis` | Archive only |

## Build validation (local)
- `npm run build` (Next.js 16) — PASS
- `npm run build:static` (`scripts/build.js`) — PASS; config no longer proxies archive Render

## Safety
No wallet signing, mint, liquidity, staking, bridge, or private key use.

## Follow-on
- **C)** Read-only multi-repo secrets inventory
- **A)** `REPO_ROLES.md` on Quantum-pi-forge